### PR TITLE
Fix multiline Windows executable detection

### DIFF
--- a/src/__tests__/env-manager.test.ts
+++ b/src/__tests__/env-manager.test.ts
@@ -6,9 +6,35 @@
 import { describe, it, expect } from 'vitest';
 import os from 'os';
 import path from 'path';
-import { EnvManager } from '../main/env-manager';
+import { EnvManager, selectExecutablePath } from '../main/env-manager';
 
 const envManager = new EnvManager();
+
+describe('selectExecutablePath', () => {
+  it('prefers the .cmd shim from multiline Windows where output', () => {
+    const output = [
+      String.raw`C:\Program Files\nodejs\npx`,
+      String.raw`C:\Program Files\nodejs\npx.cmd`,
+    ].join('\r\n');
+
+    expect(selectExecutablePath(output, 'npx', 'win32')).toBe(String.raw`C:\Program Files\nodejs\npx.cmd`);
+  });
+
+  it('falls back to the first Windows candidate when no shim is present', () => {
+    const output = [
+      String.raw`C:\Tools\uvx`,
+      String.raw`C:\OtherTools\uvx`,
+    ].join('\n');
+
+    expect(selectExecutablePath(output, 'uvx', 'win32')).toBe(String.raw`C:\Tools\uvx`);
+  });
+
+  it('uses the first candidate on non-Windows platforms', () => {
+    const output = ['/usr/local/bin/npx', '/opt/homebrew/bin/npx'].join('\n');
+
+    expect(selectExecutablePath(output, 'npx', 'darwin')).toBe('/usr/local/bin/npx');
+  });
+});
 
 describe('getEnhancedPath', () => {
   it('应包含当前 PATH', () => {

--- a/src/main/env-manager.ts
+++ b/src/main/env-manager.ts
@@ -10,6 +10,33 @@ import os from 'os';
 
 const execAsync = promisify(exec);
 
+export function selectExecutablePath(
+  commandOutput: string | null,
+  executableName: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (!commandOutput) return null;
+
+  const candidates = commandOutput
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .filter(Boolean);
+
+  if (candidates.length === 0) return null;
+
+  if (platform === 'win32') {
+    const executable = executableName.toLowerCase();
+    const winBasename = (candidate: string) => path.win32.basename(candidate).toLowerCase();
+    return (
+      candidates.find((candidate) => winBasename(candidate) === `${executable}.cmd`) ||
+      candidates.find((candidate) => winBasename(candidate) === `${executable}.exe`) ||
+      candidates[0]
+    );
+  }
+
+  return candidates[0];
+}
+
 export interface RuntimeInfo {
   available: boolean;
   version: string | null;
@@ -85,7 +112,7 @@ export class EnvManager {
       return {
         available: true,
         version: version.replace('v', ''),
-        path: nodePath,
+        path: selectExecutablePath(nodePath, 'node'),
       };
     }
     return { available: false, version: null, path: null };
@@ -110,7 +137,7 @@ export class EnvManager {
       return {
         available: true,
         version: version.replace('Python ', ''),
-        path: pythonPath,
+        path: selectExecutablePath(pythonPath, 'python'),
       };
     }
     return { available: false, version: null, path: null };
@@ -127,7 +154,7 @@ export class EnvManager {
       return {
         available: true,
         version,
-        path: npxPath,
+        path: selectExecutablePath(npxPath, 'npx'),
       };
     }
     return { available: false, version: null, path: null };
@@ -144,7 +171,7 @@ export class EnvManager {
       return {
         available: true,
         version,
-        path: uvxPath,
+        path: selectExecutablePath(uvxPath, 'uvx'),
       };
     }
     return { available: false, version: null, path: null };


### PR DESCRIPTION
Fixes Windows runtime detection when `where npx` or another lookup command returns more than one path.

## Summary
- add a shared executable-path selector for `which` / `where` output
- prefer Windows `.cmd` shims, then `.exe`, then the first candidate
- apply the selector to node, python, npx, and uvx runtime paths so multiline lookup output is never written as a server command
- cover multiline Windows lookup output and non-Windows first-candidate behavior in EnvManager tests

## Validation
- `npx.cmd vitest run src\\__tests__\\env-manager.test.ts`
- `npm.cmd test`
- `npm.cmd run build:main`
- `git diff --check`

Fixes #9
